### PR TITLE
fix issue 1

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -25,7 +25,7 @@ use graphene_std::raster::{
 use graphene_std::table::{Table, TableRow};
 use graphene_std::text::{Font, TextAlign};
 use graphene_std::transform::{Footprint, ReferencePoint, Transform};
-use graphene_std::vector::misc::{ArcType, CentroidType, ExtrudeJoiningAlgorithm, GridType, MergeByDistanceAlgorithm, PointSpacingType, SpiralType};
+use graphene_std::vector::misc::{AngularSpacing, ArcType, CentroidType, ExtrudeJoiningAlgorithm, GridType, MergeByDistanceAlgorithm, PointSpacingType, RepeatSpacing, SpiralType};
 use graphene_std::vector::style::{Fill, FillChoice, FillType, GradientStops, GradientType, PaintOrder, StrokeAlign, StrokeCap, StrokeJoin};
 
 pub(crate) fn string_properties(text: &str) -> Vec<LayoutGroup> {
@@ -223,6 +223,8 @@ pub(crate) fn property_from_type(
 						Some(x) if x == TypeId::of::<MergeByDistanceAlgorithm>() => enum_choice::<MergeByDistanceAlgorithm>().for_socket(default_info).property_row(),
 						Some(x) if x == TypeId::of::<ExtrudeJoiningAlgorithm>() => enum_choice::<ExtrudeJoiningAlgorithm>().for_socket(default_info).property_row(),
 						Some(x) if x == TypeId::of::<PointSpacingType>() => enum_choice::<PointSpacingType>().for_socket(default_info).property_row(),
+						Some(x) if x == TypeId::of::<RepeatSpacing>() => enum_choice::<RepeatSpacing>().for_socket(default_info).property_row(),
+						Some(x) if x == TypeId::of::<AngularSpacing>() => enum_choice::<AngularSpacing>().for_socket(default_info).property_row(),
 						Some(x) if x == TypeId::of::<BooleanOperation>() => enum_choice::<BooleanOperation>().for_socket(default_info).property_row(),
 						Some(x) if x == TypeId::of::<CentroidType>() => enum_choice::<CentroidType>().for_socket(default_info).property_row(),
 						Some(x) if x == TypeId::of::<LuminanceCalculation>() => enum_choice::<LuminanceCalculation>().for_socket(default_info).property_row(),

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -254,6 +254,8 @@ tagged_value! {
 	MergeByDistanceAlgorithm(vector::misc::MergeByDistanceAlgorithm),
 	ExtrudeJoiningAlgorithm(vector::misc::ExtrudeJoiningAlgorithm),
 	PointSpacingType(vector::misc::PointSpacingType),
+	RepeatSpacing(vector::misc::RepeatSpacing),
+	AngularSpacing(vector::misc::AngularSpacing),
 	SpiralType(vector::misc::SpiralType),
 	#[serde(alias = "LineCap")]
 	StrokeCap(vector::style::StrokeCap),

--- a/node-graph/libraries/vector-types/src/vector/misc.rs
+++ b/node-graph/libraries/vector-types/src/vector/misc.rs
@@ -104,6 +104,26 @@ pub enum PointSpacingType {
 	Quantity,
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash, DynAny, specta::Type, node_macro::ChoiceType)]
+#[widget(Radio)]
+pub enum RepeatSpacing {
+	#[default]
+	Span,
+	Pitch,
+	Envelope,
+	Gap,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash, DynAny, specta::Type, node_macro::ChoiceType)]
+#[widget(Radio)]
+pub enum AngularSpacing {
+	Span,
+	#[default]
+	Pitch,
+}
+
 pub fn point_to_dvec2(point: Point) -> DVec2 {
 	DVec2 { x: point.x, y: point.y }
 }


### PR DESCRIPTION
fix #1 

Added RepeatSpacing (Span/Pitch/Envelope/Gap) and AngularSpacing (Span/Pitch) choice enums.

Updated repeat to compute translation spacing based on the selected method, using the instance bounding box width along the direction for Envelope/Gap. Also avoids the count=1 divide-by-zero edge case.

Updated circular_repeat to take start_angle, end_angle, and spacing. In Span mode, it distributes from start to end. In Pitch mode, end_angle is interpreted as the pitch (0 defaults to full-circle spacing).

Updated tests to pass the new parameters.
